### PR TITLE
Mezzanine 4.x Compatibility

### DIFF
--- a/mezzanine_wymeditor/widgets.py
+++ b/mezzanine_wymeditor/widgets.py
@@ -14,7 +14,7 @@ class WymeditorWidget(forms.Textarea):
             )
         }
         js = (
-            'mezzanine/js/jquery-ui-1.9.1.custom.min.js',
+            'mezzanine/js/' + settings.JQUERY_UI_FILENAME,
             'filebrowser/js/filebrowser-popup.js',
             'mezzanine_wymeditor/wymeditor/jquery.wymeditor.min.js',
             'mezzanine_wymeditor/wymeditor/plugins/embed/jquery.wymeditor.embed.js',

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,7 @@ setup(
         'Framework :: Django',
         'Environment :: Web Environment'
     ],
+    install_requires=[
+        "mezzanine >= 4.0.0",
+    ],
 )


### PR DESCRIPTION
The JQUERY_UI_FILENAME setting is new in 4.x so we'll need to require
mezzanine>=4.0.0.
